### PR TITLE
Replace Run impl on Windows due to polling problems

### DIFF
--- a/alire.toml
+++ b/alire.toml
@@ -1,5 +1,5 @@
 name = "aaa"
-version = "0.2.1"
+version = "0.2.2"
 description = "Alex's Ada Assortment (of miscellaneous utilities)"
 
 long-description = """

--- a/src/aaa-processes.adb
+++ b/src/aaa-processes.adb
@@ -1,10 +1,141 @@
---  with Ada.Text_IO; use Ada.Text_IO;
+with Ada.Text_IO; use Ada.Text_IO;
 with GNAT.Expect;
-with GNAT.OS_Lib;
 
 package body AAA.Processes is
 
    package OS renames GNAT.OS_Lib;
+
+   -------------
+   -- To_List --
+   -------------
+
+   function To_List (V : aliased Strings.Vector) return OS.Argument_List
+   --  Reuse the strings in V for the argument list, so this V should
+   --  outlive the result usage.
+   is
+      Pos : Positive := 1;
+   begin
+      return List : OS.Argument_List (1 .. V.Count) do
+         for I in V.First_Index .. V.Last_Index loop
+            List (Pos) := V.Constant_Reference (I).Element;
+            Pos := Pos + 1;
+         end loop;
+      end return;
+   end To_List;
+
+   -----------------------
+   -- Spawn_And_Capture --
+   -----------------------
+
+   function Spawn_And_Capture
+     (Output              : in out Strings.Vector;
+      Command             : String;
+      Arguments           : Strings.Vector;
+      Err_To_Out          : Boolean := False)
+     return Integer
+   is
+      use GNAT.OS_Lib;
+      File     : File_Descriptor;
+      Name     : String_Access;
+
+      Arg_List : aliased constant Argument_List := To_List (Arguments);
+
+      Outfile : File_Type;
+
+      Exit_Code : Integer;
+
+      -------------
+      -- Cleanup --
+      -------------
+
+      procedure Cleanup is
+         Ok : Boolean;
+      begin
+         Delete_File (Name.all, Ok);
+         if not Ok then
+            Put_Line ("Failed to delete tmp file: " & Name.all);
+         end if;
+
+         Free (Name);
+      end Cleanup;
+
+      -----------------
+      -- Read_Output --
+      -----------------
+
+      procedure Read_Output is
+      begin
+         Open (Outfile, In_File, Name.all);
+         while not End_Of_File (Outfile) loop
+            Output.Append (Get_Line (Outfile));
+         end loop;
+         Close (Outfile);
+      end Read_Output;
+
+   begin
+      Create_Temp_Output_File (File, Name);
+
+      --  Put_Line ("Spawning: "
+      --            & Command & " " & Arguments.Flatten
+      --            & " > " & Name.all);
+
+      Spawn (Program_Name           => Command,
+             Args                   => Arg_List,
+             Output_File_Descriptor => File,
+             Return_Code            => Exit_Code,
+             Err_To_Out             => Err_To_Out);
+
+      Close (File); -- Can't raise
+      Read_Output;
+
+      Cleanup;
+      return Exit_Code;
+   end Spawn_And_Capture;
+
+   ----------------
+   -- Get_Output --
+   ----------------
+   --  This shouldn't exist, but problems with Windows polling force us to
+   --  do our own reimplementation. Offending call in GNAT.Expect:700 to
+   --  Poll hangs.
+   function Get_Output (Command_Line : Strings.Vector;
+                        Input        : String := "";
+                        Exit_Code    : aliased out Integer;
+                        Err_To_Out   : Boolean := False)
+                        return String
+   is
+      use GNAT.Expect;
+      Arguments : aliased constant Strings.Vector := Command_Line.Tail;
+      Output    : Strings.Vector;
+   begin
+      if GNAT.OS_Lib.Directory_Separator = '\' then -- Windows
+
+         --  For some unknown reason we get no output on Windows, no matter how
+         --  the call to Expect is made. Falling back to plain Spawn without
+         --  user input (!).
+
+         if Input /= "" and then GNAT.OS_Lib.Directory_Separator = '\' then
+            raise Unimplemented
+              with "Spawning with user input is unuspported on Windows";
+         end if;
+
+         Exit_Code := Spawn_And_Capture
+           (Output              => Output,
+            Command             => Command_Line.First_Element,
+            Arguments           => Command_Line.Tail,
+            Err_To_Out          => Err_To_Out);
+
+         return Output.Flatten (ASCII.LF);
+
+      else
+         return Get_Command_Output
+           (Command    => Command_Line.First_Element,
+            Arguments  => To_List (Arguments),
+            Input      => Input,
+            Status     => Exit_Code'Access,
+            Err_To_Out => Err_To_Out);
+      end if;
+   end Get_Output;
 
    ---------
    -- Run --
@@ -18,26 +149,6 @@ package body AAA.Processes is
       return Result
    is
 
-      -------------
-      -- To_List --
-      -------------
-
-      function To_List (V : aliased Strings.Vector) return OS.Argument_List
-      --  Reuse the strings in V for the argument list, so this V should
-      --  outlive the result usage.
-      is
-         Pos : Positive := 1;
-      begin
-         return List : OS.Argument_List (1 .. V.Count) do
-            for I in V.First_Index .. V.Last_Index loop
-               List (Pos) := V.Constant_Reference (I).Element;
-               Pos := Pos + 1;
-            end loop;
-         end return;
-      end To_List;
-
-      use GNAT.Expect;
-      Arguments : aliased constant Strings.Vector := Command_Line.Tail;
    begin
       --  Put_Line ("RUNNING: " & Command_Line.Flatten);
 
@@ -45,12 +156,11 @@ package body AAA.Processes is
          R.Output :=
            Strings.Split
              (Strings.Replace
-                (Get_Command_Output
-                   (Command    => Command_Line.First_Element,
-                    Arguments  => To_List (Arguments),
-                    Input      => Input,
-                    Status     => R.Exit_Code'Access,
-                    Err_To_Out => Err_To_Out),
+                (Get_Output
+                   (Command_Line => Command_Line,
+                    Input        => Input,
+                    Exit_Code    => R.Exit_Code,
+                    Err_To_Out   => Err_To_Out),
                  Match => ASCII.CR & ASCII.LF,
                  Subst => (1 => ASCII.LF)),
               Separator => ASCII.Lf);

--- a/src/aaa-processes.ads
+++ b/src/aaa-processes.ads
@@ -1,5 +1,7 @@
 with AAA.Strings;
 
+with GNAT.OS_Lib;
+
 package AAA.Processes is
 
    Child_Error : exception;
@@ -13,10 +15,17 @@ package AAA.Processes is
                  Input          : String := "";
                  Err_To_Out     : Boolean := False;
                  Raise_On_Error : Boolean := True)
-                 return Result;
+                 return Result with
+     Pre =>
+       Input = "" or else
+       GNAT.OS_Lib.Directory_Separator /= '\' or else
+       raise Unimplemented with "Spawning with user input is unuspported on Windows";
    --  Run a command, giving optional Input to it, and capture its output,
    --  optionally including stderr output. If the child's process exit code is
    --  /= 0, Child_Error will be raised when Raise_On_Error. CR & LF sequences
-   --  will be interpreted as plain LF sequences.
+   --  will be interpreted as plain LF sequences. NOTE: due to unresolved
+   --  problems with Windows polling, on Windows Input *must* be "", and a
+   --  temporary file will be created on the current directory during process
+   --  spawning. (Might affect git status and the like, for example.)
 
 end AAA.Processes;

--- a/src/aaa.ads
+++ b/src/aaa.ads
@@ -1,3 +1,5 @@
 package AAA with Pure is
 
+   Unimplemented : exception;
+
 end AAA;


### PR DESCRIPTION
`GNAT.Expect.Poll` is hanging for unknown reasons on Windows. `-gnatP` makes no difference. Manual polling using timeouts also doesn't read any output.

Falling back to `GNAT.OS_Lib.Spawn` for the moment. This means that, on Windows, there cannot be user input to the process.